### PR TITLE
i18n gem dependency fix

### DIFF
--- a/redis-i18n.gemspec
+++ b/redis-i18n.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'redis-store',   '~> 1.1.0'
-  s.add_runtime_dependency 'i18n',          '~> 0.6.0'
+  s.add_runtime_dependency 'i18n',          '~> 0.7.0'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.3'


### PR DESCRIPTION
for bundler issues such as:

```
Bundler could not find compatible versions for gem "i18n":
  In Gemfile:
    redis-i18n (>= 0) ruby depends on
      i18n (~> 0.6.0) ruby

    rails (= 4.2.5) ruby depends on
      activejob (= 4.2.5) ruby depends on
        activesupport (= 4.2.5) ruby depends on
          i18n (~> 0.7) ruby
```

because rails/activesupport (4.2.5) has a [dependency to the i18n gem (~> 0.7)](https://github.com/rails/rails/blob/master/activesupport/activesupport.gemspec#L23)
