### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/redis-i18n.gemspec
+++ b/redis-i18n.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.description = %q{Redis backed store for i18n}
   s.license     = 'MIT'
 
-  s.rubyforge_project = 'redis-i18n'
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.