### PR TITLE
Relax i18n dependency

### DIFF
--- a/redis-i18n.gemspec
+++ b/redis-i18n.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'redis-store',   '~> 1'
-  s.add_runtime_dependency 'i18n',          '~> 0.7.0'
+  s.add_runtime_dependency 'i18n',          '>= 0.7', '< 2'
 
   s.add_development_dependency 'rake',     '>= 12.3.3'
   s.add_development_dependency 'bundler',  '~> 2'


### PR DESCRIPTION
This PR relaxes the i18n dependency. No major changes in i18n that should affect this gem.